### PR TITLE
Replace readFileStr() with Deno.readTextFile() in authlete_configuration_property.ts.

### DIFF
--- a/src/config/authlete_configuration_property.ts
+++ b/src/config/authlete_configuration_property.ts
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 
-import { readFileStr } from 'https://deno.land/std/fs/read_file_str.ts';
 import { AuthleteConfiguration } from './authlete_configuration.ts';
 
 
@@ -54,7 +53,7 @@ type properties = { [key: string]: any };
 async function loadProperty(propertyFileName: string): Promise<properties>
 {
     // Read the property file.
-    const file = await readFileStr(propertyFileName).catch(() => {
+    const file = await Deno.readTextFile(propertyFileName).catch(() => {
         // Failed to read the property file.
         throw new Error(`Failed to read ${propertyFileName}`);
     });


### PR DESCRIPTION
Relaced readFileStr() with Deno.readTextFile() in authlete_configuration_property.ts since readFileStr() was removed by https://github.com/denoland/deno/pull/6848.