### PR TITLE
[feature] Add support for token management APIs

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -24,6 +24,7 @@ export * from './src/config/authlete_configuration.ts';
 export * from './src/config/authlete_configuration_property.ts';
 
 // dto
+export * from './src/dto/access_token.ts';
 export * from './src/dto/address.ts';
 export * from './src/dto/api_response.ts';
 export * from './src/dto/authorization_fail_request.ts';
@@ -69,13 +70,20 @@ export * from './src/dto/sns_credentials.ts';
 export * from './src/dto/standard_introspection_request.ts';
 export * from './src/dto/standard_introspection_response.ts';
 export * from './src/dto/tagged_value.ts';
+export * from './src/dto/token_create_request.ts';
+export * from './src/dto/token_create_response.ts';
 export * from './src/dto/token_fail_request.ts';
 export * from './src/dto/token_fail_response.ts';
 export * from './src/dto/token_info.ts';
 export * from './src/dto/token_issue_request.ts';
 export * from './src/dto/token_issue_response.ts';
+export * from './src/dto/token_list_response.ts';
 export * from './src/dto/token_request.ts';
 export * from './src/dto/token_response.ts';
+export * from './src/dto/token_revoke_request.ts';
+export * from './src/dto/token_revoke_response.ts';
+export * from './src/dto/token_update_request.ts';
+export * from './src/dto/token_update_response.ts';
 export * from './src/dto/user_info_issue_request.ts';
 export * from './src/dto/user_info_issue_response.ts';
 export * from './src/dto/user_info_request.ts';

--- a/src/api/authlete_api.ts
+++ b/src/api/authlete_api.ts
@@ -45,12 +45,19 @@ import { Service } from '../dto/service.ts';
 import { ServiceListResponse } from '../dto/service_list_response.ts';
 import { StandardIntrospectionRequest } from '../dto/standard_introspection_request.ts';
 import { StandardIntrospectionResponse } from '../dto/standard_introspection_response.ts';
+import { TokenCreateRequest } from '../dto/token_create_request.ts';
+import { TokenCreateResponse } from '../dto/token_create_response.ts';
 import { TokenFailRequest } from '../dto/token_fail_request.ts';
 import { TokenFailResponse } from '../dto/token_fail_response.ts';
 import { TokenIssueRequest } from '../dto/token_issue_request.ts';
 import { TokenIssueResponse } from '../dto/token_issue_response.ts';
+import { TokenListResponse } from '../dto/token_list_response.ts';
 import { TokenRequest } from '../dto/token_request.ts';
 import { TokenResponse } from '../dto/token_response.ts';
+import { TokenRevokeRequest } from '../dto/token_revoke_request.ts';
+import { TokenRevokeResponse } from '../dto/token_revoke_response.ts';
+import { TokenUpdateRequest } from '../dto/token_update_request.ts';
+import { TokenUpdateResponse } from '../dto/token_update_response.ts';
 import { UserInfoIssueRequest } from '../dto/user_info_issue_request.ts';
 import { UserInfoIssueResponse } from '../dto/user_info_issue_response.ts';
 import { UserInfoRequest } from '../dto/user_info_request.ts';
@@ -117,6 +124,62 @@ export interface AuthleteApi
 
 
     /**
+     * Call `/auth/token/get/list` API.
+     *
+     * @param subject
+     *         Unique user ID.
+     *
+     * @param clientId
+     *         Client Identifier (client ID or client ID alias).
+     *
+     * @param start
+     *         Start index of search results (inclusive). The default
+     *         value is `0`.
+     *
+     * @param end
+     *         End index of search results (exclusive). The default
+     *         value is `5`.
+     */
+    getTokenList(subject?: string, clientIdentifier?: string, start?: number, end?: number): Promise<TokenListResponse>
+
+
+    /**
+     * Call `/auth/token/create` API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     */
+    tokenCreate(request: TokenCreateRequest): Promise<TokenCreateResponse>
+
+
+    /**
+     * Call `/auth/token/update` API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     */
+    tokenUpdate(request: TokenUpdateRequest): Promise<TokenUpdateResponse>
+
+
+    /**
+     * Call `/auth/token/delete` API.
+     *
+     * @param token
+     *         An access token or its hash value.
+     */
+    tokenDelete(token: string): Promise<void>
+
+
+    /**
+     * Call `/auth/token/revoke` API.
+     *
+     * @param request
+     *         Request parameters passed to the API.
+     */
+    tokenRevoke(request: TokenRevokeRequest): Promise<TokenRevokeResponse>
+
+
+    /**
      * Call Authlete `/auth/revocation` API.
      *
      * @param request
@@ -175,11 +238,11 @@ export interface AuthleteApi
      *
      * @param start
      *         The start index (inclusive) of the result set. The default
-     *         value is 0. Must not be a negative number.
+     *         value is `0`. Must not be a negative number.
      *
      * @param end
      *         The end index (exclusive) of the result set. The default
-     *         value is 5. Must not be a negative number.
+     *         value is `5`. Must not be a negative number.
      */
     getServiceList(start?: number, end?: number): Promise<ServiceListResponse>
 
@@ -275,11 +338,11 @@ export interface AuthleteApi
      *
      * @param start
      *         The start index (inclusive) of the result set. The default
-     *         value is 0. Must not be a negative number.
+     *         value is `0`. Must not be a negative number.
      *
      * @param end
      *         The end index (exclusive) of the result set. The default
-     *         value is 5. Must not be a negative number.
+     *         value is `5`. Must not be a negative number.
      */
     getClientList(developer?: string, start?: number, end?: number): Promise<ClientListResponse>;
 

--- a/src/api/authlete_api_impl.ts
+++ b/src/api/authlete_api_impl.ts
@@ -48,12 +48,17 @@ import { Service } from '../dto/service.ts';
 import { ServiceListResponse } from '../dto/service_list_response.ts';
 import { StandardIntrospectionRequest } from '../dto/standard_introspection_request.ts';
 import { StandardIntrospectionResponse } from '../dto/standard_introspection_response.ts';
+import { TokenCreateRequest } from '../dto/token_create_request.ts';
+import { TokenCreateResponse } from '../dto/token_create_response.ts';
 import { TokenFailRequest } from '../dto/token_fail_request.ts';
 import { TokenFailResponse } from '../dto/token_fail_response.ts';
 import { TokenIssueRequest } from '../dto/token_issue_request.ts';
 import { TokenIssueResponse } from '../dto/token_issue_response.ts';
+import { TokenListResponse } from '../dto/token_list_response.ts';
 import { TokenRequest } from '../dto/token_request.ts';
 import { TokenResponse } from '../dto/token_response.ts';
+import { TokenUpdateRequest } from '../dto/token_update_request.ts';
+import { TokenUpdateResponse } from '../dto/token_update_response.ts';
 import { UserInfoIssueRequest } from '../dto/user_info_issue_request.ts';
 import { UserInfoIssueResponse } from '../dto/user_info_issue_response.ts';
 import { UserInfoRequest } from '../dto/user_info_request.ts';
@@ -62,6 +67,8 @@ import { isNotUndefined } from '../util/util.ts';
 import { BasicCredentials } from '../web/basic_credentials.ts';
 import { AuthleteApi } from './authlete_api.ts';
 import { AuthleteApiException } from './authlete_api_exception.ts';
+import { TokenRevokeRequest } from '../dto/token_revoke_request.ts';
+import { TokenRevokeResponse } from '../dto/token_revoke_response.ts';
 const { classToPlain, plainToClass } = ct;
 
 
@@ -79,8 +86,13 @@ const DEVICE_AUTHORIZATION_API_PATH                = '/device/authorization';
 const DEVICE_VERIFICATION_API_PATH                 = '/device/verification';
 const DEVICE_COMPLETE_API_PATH                     = '/device/complete';
 const TOKEN_API_PATH                               = '/auth/token';
-const TOKEN_ISSUE_API_PATH                         = '/auth/token/issue';
+const TOKEN_CREATE_API_PATH                        = '/auth/token/create';
+const TOKEN_DELETE_API_PATH                        = '/auth/token/delete/{accessTokenIdentifier}';
 const TOKEN_FAIL_API_PATH                          = '/auth/token/fail';
+const TOKEN_GET_LIST_API_PATH                      = '/auth/token/get/list';
+const TOKEN_ISSUE_API_PATH                         = '/auth/token/issue';
+const TOKEN_REVOKE_API_PATH                        = '/auth/token/revoke';
+const TOKEN_UPDATE_API_PATH                        = '/auth/token/update';
 const REVOCATION_API_PATH                          = '/auth/revocation';
 const USER_INFO_API_PATH                           = '/auth/userinfo';
 const USER_INFO_ISSUE_API_PATH                     = '/auth/userinfo/issue';
@@ -433,6 +445,23 @@ function buildQueryParamsForClientGetListApi(
 
 
 /**
+ * Create a request for `/auth/token/get/list` API.
+ */
+ function buildQueryParamsForTokenGetListApi(
+    subject?: string, clientIdentifier?: string, start?: number, end?: number): QueryParams
+{
+    const request: QueryParams = {};
+
+    if (isNotUndefined(start)) request['start'] = start.toString();
+    if (isNotUndefined(end)) request['end'] = end.toString();
+    if (isNotUndefined(subject)) request['subject'] = subject;
+    if (isNotUndefined(clientIdentifier)) request['clientIdentifier'] = clientIdentifier;
+
+    return request;
+}
+
+
+/**
  * An implementation of `AuthleteApi` interface.
  */
 export class AuthleteApiImpl implements AuthleteApi
@@ -615,6 +644,42 @@ export class AuthleteApiImpl implements AuthleteApi
     {
         return <Promise<TokenFailResponse>>
             this.callServicePostApi(TOKEN_FAIL_API_PATH, request, TokenFailResponse);
+    }
+
+
+    public async getTokenList(
+        subject?: string, clientIdentifier?: string, start?: number, end?: number)
+    {
+        return <Promise<TokenListResponse>>this.callServiceGetApi(
+            TOKEN_GET_LIST_API_PATH, buildQueryParamsForTokenGetListApi(subject, clientIdentifier, start, end), TokenListResponse);
+    }
+
+
+    public async tokenCreate(request: TokenCreateRequest)
+    {
+        return <Promise<TokenCreateResponse>>
+            this.callServicePostApi(TOKEN_CREATE_API_PATH, request, TokenCreateResponse);
+    }
+
+
+    public async tokenUpdate(request: TokenUpdateRequest)
+    {
+        return <Promise<TokenUpdateResponse>>
+            this.callServicePostApi(TOKEN_UPDATE_API_PATH, request, TokenUpdateResponse);
+    }
+
+
+    public async tokenDelete(accessTokenIdentifier: string)
+    {
+        await this.callServiceDeleteApi(
+            TOKEN_DELETE_API_PATH.replace('{accessTokenIdentifier}', accessTokenIdentifier.toString()));
+    }
+
+
+    public async tokenRevoke(request: TokenRevokeRequest)
+    {
+        return <Promise<TokenRevokeResponse>>
+            this.callServicePostApi(TOKEN_REVOKE_API_PATH, request, TokenRevokeResponse);
     }
 
 

--- a/src/dto/access_token.ts
+++ b/src/dto/access_token.ts
@@ -1,0 +1,103 @@
+// Copyright (C) 2022 Authlete, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import ct from 'https://cdn.pika.dev/class-transformer@^0.2.3';
+import 'https://cdn.pika.dev/reflect-metadata@^0.1.13';
+import { fromJsonValue } from '../type/base_extended_enum.ts';
+import { GrantType } from '../type/grant_type.ts';
+import { Property } from './property.ts';
+const { Type, Transform } = ct;
+
+
+/**
+ * Information about an access token.
+ */
+export class AccessToken
+{
+    /**
+     * The hash of the access token.
+     */
+    public accessTokenHash?: string;
+
+
+    /**
+     * The hash of the refresh token.
+     */
+    public refreshTokenHash?: string;
+
+
+    /**
+     * The ID of the client associated with the access token.
+     */
+    public clientId!: number;
+
+
+    /**
+     * The subject (= unique user ID) associated with the access token
+     * or `null` if the access token was created using the [Client Credentials](https://tools.ietf.org/html/rfc6749#section-4.4)
+     * flow.
+     */
+    public subject?: string;
+
+
+    /**
+     * The grant type of the access token when the access token was created.
+     * Note that the value of the grant type is not changed when the access
+     * token is refreshed using the refresh token.
+     */
+    @Transform((value: any) => fromJsonValue(value, GrantType), { toClassOnly: true })
+    public grantType!: GrantType;
+
+
+    /**
+     * The scopes covered by the access token.
+     */
+    public scopes?: string[];
+
+
+    /**
+     * The timestamp at which the access token will expire.
+     */
+    public accessTokenExpiresAt!: number;
+
+
+    /**
+     * The timestamp at which the refresh token will expire. `0` is returned
+     * if `refreshTokenHash` is `null`.
+     */
+    public refreshTokenExpiresAt!: number;
+
+
+    /**
+     * The timestamp at which the access token was first created. Note
+     * that the value of the timestamp is not changed when the access
+     * token is refreshed with the refresh token.
+     */
+    public createdAt!: number;
+
+
+    /**
+     * The timestamp at which the access token was last refreshed using
+     * the refresh token. `0` is returned if it has never been refreshed.
+     */
+    public lastRefreshedAt!: number;
+
+
+    /**
+     * The properties associated with the access token.
+     */
+    @Type(() => Property)
+    public properties?: Property[];
+}

--- a/src/dto/client.ts
+++ b/src/dto/client.ts
@@ -645,7 +645,7 @@ export class Client
      * to be in an ID token. Regardless of the value of this property,
      * Authlete embeds the `auth_time` claim when `authTime` parameter
      * in the `/auth/authorization/issue` request is not 0 and does not
-     * do it when `authTime` is 0.
+     * do it when `authTime` is `0`.
      *
      * This property corresponds to `require_auth_time` in [OpenID Connect
      * Dynamic Client Registration 1.0, 2. Client Metadata](

--- a/src/dto/service.ts
+++ b/src/dto/service.ts
@@ -871,7 +871,7 @@ export class Service
      *
      * Authlete Server searches the JWK Set for a JWK which satisfies
      * conditions for authorization response signature. If the number
-     * of JWK candidates which satisfy the conditions is 1, there is
+     * of JWK candidates which satisfy the conditions is `1`, there is
      * no problem. On the other hand, if there exist multiple candidates,
      * a Key ID is needed to be specified so that Authlete Server can
      * pick up one JWK from among the JWK candidates. This property

--- a/src/dto/token_create_request.ts
+++ b/src/dto/token_create_request.ts
@@ -1,0 +1,253 @@
+// Copyright (C) 2022 Authlete, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import ct from 'https://cdn.pika.dev/class-transformer@^0.2.3';
+import 'https://cdn.pika.dev/reflect-metadata@^0.1.13';
+import { toJsonValue } from '../type/base_extended_enum.ts';
+import { GrantType } from '../type/grant_type.ts';
+import { AuthzDetails } from './authz_details.ts';
+import { Property } from './property.ts';
+const { Type, Transform } = ct;
+
+
+/**
+ * Request to Authlete `/auth/token/create` API.
+ */
+export class TokenCreateRequest
+{
+    /**
+     * The grant type for a newly created access token.
+     */
+    @Transform(toJsonValue, { toPlainOnly: true })
+    public grantType?: GrantType;
+
+
+    /**
+     * The client ID that will be associated with a newly created access
+     * token.
+     */
+    public clientId?: string
+
+
+    /**
+     * The subject (= unique identifier) of the user who will be associated
+     * with a newly created access token.
+     */
+    public subject?: string;
+
+
+    /**
+     * The scopes that will be associated with a newly created access
+     * token.
+     */
+    public scopes?: string[];
+
+
+    /**
+     * The duration of a newly created access token in seconds. 0 means
+     * that the duration will be determined according to the settings
+     * of the service.
+     */
+    public accessTokenDuration!: number;
+
+
+    /**
+     * The duration of a newly created refresh token in seconds. 0 means
+     * that the duration will be determined according to the settings
+     * of the service.
+     */
+    public refreshTokenDuration!: number;
+
+
+    /**
+     * The extra properties to associate with an access token which will
+     * be issued by this request.
+     *
+     * Keys of extra properties will be used as labels of top-level
+     * entries in a JSON response containing an access token which is
+     * returned from an authorization server. An example is
+     * `example_parameter`, which you can find in [5.1. Successful Response](
+     * https://tools.ietf.org/html/rfc6749#section-5.1) in RFC 6749. The
+     * following code snippet is an example to set one extra property
+     * having `example_parameter` as its key and `example_value` as its
+     * value.
+     *
+     * ```
+     * const property = new Property();
+     * property.key   = 'example_parameter';
+     * property.value = 'example_value';
+     * request.properties = [ property ];
+     * ```
+     *
+     * Keys listed below should not be used and they would be ignored
+     * on the server side even if they were used. It's because they are
+     * reserved in [RFC 6749](https://tools.ietf.org/html/rfc6749) and
+     * [OpenID Connect Core 1.0](http://openid.net/specs/openid-connect-core-1_0.html).
+     *
+     * - `access_token`
+     * - `token_type`
+     * - `expires_in`
+     * - `refresh_token`
+     * - `scope`
+     * - `error`
+     * - `error_description`
+     * - `error_uri`
+     * - `id_token`
+     *
+     * Note that **there is an upper limit on the total size of extra
+     * properties**. On the server side, the properties will be (1) converted
+     * to a multidimensional string array, (2) converted to JSON, (3)
+     * encrypted by AES/CBC/PKCS5Padding, (4) encoded by base64url, and
+     * then stored into the database. The length of the resultant string
+     * must not exceed 65,535 in bytes. This is the upper limit, but we
+     * think it is big enough.
+     */
+    @Type(() => Property)
+    public properties?: Property[];
+
+
+    /**
+     * The flag which indicates whether to emulate that the client ID
+     * alias is used instead of the original numeric client ID when a
+     * new access token is created.
+     *
+     * This has an effect only on the value of the `aud` claim in a response
+     * from [UserInfo endpoint](http://openid.net/specs/openid-connect-core-1_0.html#UserInfo).
+     * When you access the UserInfo endpoint (which is expected to be
+     * implemented using Authlete's `/api/auth/userinfo` API and `/api/auth/userinfo/issue`
+     * API) with an access token which has been created using Authlete's
+     * `/api/auth/token/create` API with this property (`clientIdAliasUsed`)
+     * true, the client ID alias is used as the value of the `aud` claim
+     * in a response from the UserInfo endpoint.
+     *
+     * Note that if a client ID alias is not assigned to the client when
+     * Authlete's `/api/auth/token/create` API is called, this property (
+     * `clientIdAliasUsed`) has no effect (it is always regarded as `false`).
+     */
+    public clientIdAliasUsed!: boolean;
+
+
+    /**
+     * The access token.
+     *
+     * The `/api/auth/token/create` API generates an access token. Therefore,
+     * callers of the API do not have to specify values of newly created
+     * access tokens. However, in some cases, for example, if you want
+     * to migrate existing access tokens from an old system to Authlete,
+     * you may want to specify values of access tokens. In such a case,
+     * you can specify the value of a newly created access token by passing
+     * a non-null value as the value of `accessToken` request parameter.
+     * The implementation of the `/api/auth/token/create` uses the value
+     * of the `accessToken` request parameter instead of generating a
+     * new value when the request parameter holds a non-null value.
+     *
+     * Note that if the hash value of the specified access token already
+     * exists in Authlete's database, the access token cannot be inserted
+     * and the `/auth/token/create` API will report an error.
+     */
+    public accessToken?: string;
+
+
+    /**
+     * The refresh token.
+     *
+     * The `/auth/token/create` API may generate a refresh token. Therefore,
+     * callers of the API do not have to specify values of newly created
+     * refresh tokens. However, in some cases, for example, if you want
+     * to migrate existing refresh tokens from an old system to Authlete,
+     * you may want to specify values of refresh tokens. In such a case,
+     * you can specify the value of a newly created refresh token by
+     * passing a non-null value as the value of `refreshToken` request
+     * parameter. The implementation of the `/auth/token/create` uses
+     * the value of the `refreshToken` request parameter instead of generating
+     * a new value when the request parameter holds a non-null value.
+     *
+     * Note that if the hash value of the specified refresh token already
+     * exists in Authlete's database, the refresh token cannot be inserted
+     * and the `/auth/token/create` API will report an error.
+     */
+    public refreshToken?: string;
+
+
+    /**
+     * Whether the access token expires or not. By default, all access
+     * tokens expire after a period of time determined by their service.
+     * If this request parameter is `true` then the access token will
+     * not automatically expire and must be revoked or deleted manually
+     * at the service.
+     *
+     * If this request parameter is `true`, the `accessTokenDuration`
+     * request parameter is ignored.
+     */
+    public accessTokenPersistent!: boolean;
+
+
+    /**
+     * The thumbprint of the MTLS certificate bound to this token. If
+     * this field is set, a certificate with the corresponding value MUST
+     * be presented with the access token when it is used by a client.
+     */
+    public certificateThumbprint?: string;
+
+
+    /**
+     * The thumbprint of the public key used for DPoP presentation of
+     * this token. If this field is set, a DPoP proof signed with the
+     * corresponding private key MUST be presented with the access token
+     * when it is used by a client. Additionally, the token's `token_type`
+     * will be set to `'DPoP'`.
+     */
+    public dpopKeyThumbprint?: string;
+
+
+    /**
+     * The authorization details. This represents the value of the
+     * `authorization_details` request parameter which is defined in
+     * _"OAuth 2.0 Rich Authorization Requests"_.
+     */
+    @Type(() => AuthzDetails)
+    public authorizationDetails?: AuthzDetails;
+
+
+    /**
+     * the resources. This represents the value of one or more
+     * `resource` request parameters which is defined in _"RFC8707 Resource
+     * Indicators for OAuth 2.0"_.
+     */
+    public resources?: string[];
+
+
+    /**
+     * The flag which indicates whether the access token is for an external
+     * attachment.
+     *
+     * For more details, see [OpenID Connect for Identity Assurance 1.0,
+     * External Attachments](https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html#name-external-attachments).
+     */
+    public forExternalAttachment!: boolean;
+
+
+    /**
+     * The additional claims in JSON object format that are added to the
+     * payload part of the JWT access token.
+     *
+     * This request parameter has a meaning only when the format of access
+     * tokens issued by this service is JWT. In other words, it has a meaning
+     * only when the `accessTokenSignAlg` property of the service holds
+     * a non-null value. See the description of the `Service.accessTokenSignAlg`
+     * for details.
+     */
+    public jwtAtClaims?: string;
+}

--- a/src/dto/token_create_response.ts
+++ b/src/dto/token_create_response.ts
@@ -1,0 +1,171 @@
+// Copyright (C) 2022 Authlete, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import ct from 'https://cdn.pika.dev/class-transformer@^0.2.3';
+import 'https://cdn.pika.dev/reflect-metadata@^0.1.13';
+import { fromJsonValue } from '../type/base_extended_enum.ts';
+import { GrantType } from '../type/grant_type.ts';
+import { ApiResponse } from './api_response.ts';
+import { AuthzDetails } from './authz_details.ts';
+import { Property } from './property.ts';
+const { Type, Transform } = ct;
+
+
+/**
+ * Response from Authlete `/auth/token/create` API.
+ */
+export class TokenCreateResponse extends ApiResponse
+{
+    /**
+     * The next action that the service implementation should take.
+     */
+    @Transform((value: any) => TokenCreateResponse.Action[value])
+    public action!: TokenCreateResponse.Action;
+
+
+    /**
+     * The grant type for a newly created access token.
+     */
+    @Transform((value: any) => fromJsonValue(value, GrantType), { toClassOnly: true })
+    public grantType!: GrantType;
+
+
+    /**
+     * The client ID.
+     */
+    public clientId!: number;
+
+
+    /**
+     * The subject (= unique identifier) of the user associated with the
+     * newly issued access token.  This value is `null` when the `grant type`
+     * obtained by `grantType` is `GrantType.CLIENT_CREDENTIALS`.
+     */
+    public subject?: string;
+
+
+    /**
+     * The scopes covered by the access token.
+     */
+    public scopes?: string[];
+
+
+    /**
+     * The newly issued access token.
+     */
+    public accessToken?: string;
+
+
+    /**
+     * The token type of the access token. For example, `"Bearer"`.
+     */
+    public tokenType?: string;
+
+
+    /**
+     * The duration of the newly issued access token in seconds.
+     */
+    public expiresIn!: number;
+
+
+    /**
+     * The date at which the newly issued access token will expire.
+     * The value is expressed in milliseconds since Unix epoch (1970-01-01).
+     */
+    public expiresAt!: number;
+
+
+    /**
+     * The newly issued Refresh token. This is `null` when the grant type
+     * is either `GrantType.IMPLICIT IMPLICIT` or `GrantType.CLIENT_CREDENTIALS CLIENT_CREDENTIALS`.
+     */
+    public refreshToken?: string;
+
+
+    /**
+     * The properties associated with the access token.
+     */
+    @Type(() => Property)
+    public properties?: Property[];
+
+
+    /**
+     * The newly issued access token in JWT format.
+     *
+     * If the authorization server is configured to issue JWT-based access
+     * tokens (= if `Service.accessTokenSignAlg` is a non-null value),
+     * a JWT-based access token is issued along with the original random-string
+     * one.
+     */
+    public jwtAccessToken?: string;
+
+
+    /**
+     * The authorization details associated with the access token.
+     */
+    @Type(() => AuthzDetails)
+    public authorizationDetails?: AuthzDetails;
+
+
+    /**
+     * The flag which indicates whether the access token is for an external
+     * attachment.
+     *
+     * For more details, see [OpenID Connect for Identity Assurance 1.0,
+     * External Attachments](https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html#name-external-attachments).
+     */
+    public forExternalAttachment!: boolean;
+
+
+    /**
+     * The unique token identifier.
+     */
+    public tokenId?: string;
+}
+
+
+export namespace TokenCreateResponse
+{
+    /**
+     * The next action that the service implementation should take.
+     */
+    export enum Action
+    {
+        /**
+         * An error occurred on Authlete side.
+         */
+        INTERNAL_SERVER_ERROR,
+
+        /**
+         * The request from the caller was wrong. For example, this
+         * happens when the `grantType` request parameter was missing.
+         */
+        BAD_REQUEST,
+
+        /**
+         * The request from the caller was not allowed. For example,
+         * this happens when the client application identified by the
+         * `clientId` request parameter does not belong to the service
+         * identified by the API key used for the API call.
+         */
+        FORBIDDEN,
+
+        /**
+         * An access token and optionally a refresh token were issued
+         * successfully.
+         */
+        OK
+    }
+}

--- a/src/dto/token_list_response.ts
+++ b/src/dto/token_list_response.ts
@@ -1,0 +1,72 @@
+// Copyright (C) 2022 Authlete, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import ct from 'https://cdn.pika.dev/class-transformer@^0.2.3';
+import 'https://cdn.pika.dev/reflect-metadata@^0.1.13';
+import { AccessToken } from './access_token.ts';
+import { Client } from "./client.ts";
+const { Type } = ct;
+
+
+/**
+ * Response from Authlete `/auth/token/get/list` API.
+ */
+export class TokenListResponse
+{
+    /**
+     * The start index (inclusive) for the result set of the query. It
+     * is the value contained in the original request (= the value of
+     * `start` parameter), or the default value (0) if the original
+     * request did not contain the parameter.
+     */
+    public start!: number;
+
+
+    /**
+     * The end index (exclusive) for the result set of the query. It
+     * is the value contained in the original request (= the value of
+     * `end` parameter), or the default value used by Authlete server
+     * if the original request did not contain the parameter.
+     */
+    public end!: number;
+
+
+    /**
+     * The total count of access tokens.
+     */
+    public totalCount!: number;
+
+
+    /**
+     * The client information associated with the value of `clientIdentifier`
+     * parameter in the original request. `null` is returned if the original
+     * request did not contain the parameter.
+     */
+    public client?: Client;
+
+
+    /**
+     * The value of `subject` parameter in the original request. `null`
+     * is returned if the original request did not contain the parameter.
+     */
+    public subject?: string;
+
+
+    /**
+     * The list of access tokens that match the query conditions.
+     */
+    @Type(() => AccessToken)
+    public accessTokens?: AccessToken[];
+}

--- a/src/dto/token_response.ts
+++ b/src/dto/token_response.ts
@@ -1,5 +1,4 @@
-// deno-lint-ignore-file
-// Copyright (C) 2020 Authlete, Inc.
+// Copyright (C) 2020-2022 Authlete, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/dto/token_revoke_request.ts
+++ b/src/dto/token_revoke_request.ts
@@ -1,0 +1,52 @@
+// Copyright (C) 2022 Authlete, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import 'https://cdn.pika.dev/reflect-metadata@^0.1.13';
+
+
+/**
+ * Request to Authlete `/auth/token/revoke` API.
+ */
+export class TokenRevokeRequest
+{
+    /**
+     * The identifier of an access token to revoke.
+     *
+     * The hash of an access token is recognized as an identifier as well
+     * as the access token itself.
+     */
+    public accessTokenIdentifier?: string;
+
+
+    /**
+     * The identifier of an refresh token to revoke.
+     *
+     * The hash of an refresh token is recognized as an identifier as
+     * well as the refresh token itself.
+     */
+    public refreshTokenIdentifier?: string;
+
+
+    /**
+     * The identifier of a client.
+     */
+    public clientIdentifier?: string;
+
+
+    /**
+     * The subject of a resource owner.
+     */
+    public subject?: string;
+}

--- a/src/dto/token_revoke_response.ts
+++ b/src/dto/token_revoke_response.ts
@@ -1,0 +1,25 @@
+// Copyright (C) 2022 Authlete, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+/**
+ * Response from Authlete `/auth/token/revoke` API.
+ */
+export class TokenRevokeResponse
+{
+    /**
+     * The number of revoked tokens.
+     */
+    public count!: number;
+}

--- a/src/dto/token_update_request.ts
+++ b/src/dto/token_update_request.ts
@@ -1,0 +1,215 @@
+// Copyright (C) 2022 Authlete, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import ct from 'https://cdn.pika.dev/class-transformer@^0.2.3';
+import 'https://cdn.pika.dev/reflect-metadata@^0.1.13';
+import { AuthzDetails } from './authz_details.ts';
+import { Property } from './property.ts';
+const { Type } = ct;
+
+
+/**
+ * Request to Authlete `/auth/token/update` API.
+ */
+export class TokenUpdateRequest
+{
+    /**
+     * An existing access token to update.
+     */
+    public accessToken?: string;
+
+
+    /**
+     * The new expiration date in milliseconds since the Unix epoch (1970-01-01).
+     */
+    public accessTokenExpiresAt!: number;
+
+
+    /**
+     * A new set of scopes assigned to the access token. If `null` is
+     * given, the scope set associated with the access token is not changed.
+     */
+    public scopes?: string[];
+
+
+    /**
+     * A new set of properties assigned to the access token.
+     *
+     * If `null` is given, the property set associated with the access
+     * token is not changed.
+     */
+    @Type(() => Property)
+    public properties?: Property[];
+
+
+    /**
+     * The flag which indicates whether `/auth/token/update` API attempts
+     * to update the expiration date of the access token when the scopes
+     * linked to the access token are changed by this request. This request
+     * parameter is optional and its default value is `false`. If this
+     * request parameter is set to `true` and all of the following conditions
+     * are satisfied, the API performs an update on the expiration date
+     * of the access token even if the `accessTokenExpiresAt` request
+     * parameter is not explicitly specified in the request.
+     *
+     * 1. The `accessTokenExpiresAt` request parameter is not included
+     * in the request or its value is 0 (or negative).
+     * 2. The scopes linked to the access token are changed by the `scopes`
+     * request parameter in the request.
+     * 3. Any of the new scopes to be linked to the access token has one
+     * or more attributes specifying access token duration.
+     *
+     * When multiple access token duration values are found in the attributes
+     * of the specified scopes, the smallest value among them is used.
+     *
+     * For more details, see the following examples.
+     *
+     * **Example 1.**
+     *
+     * Let's say we send the following request to `/auth/token/update`
+     * API
+     *
+     * ```
+     * {
+     *   "accessToken" : "JDGiiM9PuWT63FIwGjG9eYlGi-aZMq6CQ2IB475JUxs",
+     *   "scopes" : ["read_profile"]
+     * }
+     * ```
+     *
+     * and `"read_profile"` has the following attributes.
+     *
+     * ```
+     * {
+     *   "key" : "access_token.duration",
+     *   "value" : "10000"
+     * }
+     * ```
+     *
+     * In this case, the API evaluates `"10000"` as a new value of the
+     * duration of the access token (in seconds) and updates the expiration
+     * date of the access token using the duration.
+     *
+     * **Example 2.**
+     *
+     * Let's say we send the following request to `/auth/token/update`
+     * API.
+     *
+     * ```
+     * {
+     *   "accessToken" : "JDGiiM9PuWT63FIwGjG9eYlGi-aZMq6CQ2IB475JUxs",
+     *   "scopes" : ["read_profile", "write_profile"]
+     * }
+     * ```
+     *
+     * and `"read_profile"` has the following attributes
+     *
+     * ```
+     * {
+     *   "key" : "access_token.duration",
+     *   "value" : "10000"
+     * }
+     * ```
+     *
+     * and `"write_profile"` has the following attributes.
+     *
+     * ```
+     * {
+     *   "key" : "access_token.duration",
+     *   "value" : "5000"
+     * }
+     * ```
+     *
+     * In this case, the API evaluates `"10000"` and `"5000"` as candidate
+     * values for new duration of the access token (in seconds) and chooses
+     * the smallest value of them (i.e. "5000" is adopted) and updates
+     * the expiration date of the access token using the duration.
+     */
+    public accessTokenExpiresAtUpdatedOnScopeUpdate!: boolean;
+
+
+    /**
+     * Whether the access token expires or not. By default, all access
+     * tokens expire after a period of time determined by their service.
+     * If this request parameter is `true` then the access token will
+     * not automatically expire and must be revoked or deleted manually
+     * at the service.
+     *
+     * If this request parameter is `true`, the `accessTokenExpiresAt`
+     * request parameter is ignored. If this request parameter is `false`,
+     * the `accessTokenExpiresAt` request parameter is processed normally.
+     */
+    public accessTokenPersistent!: boolean;
+
+
+    /**
+     * The hash of the access token value. Used when the hash of the token
+     * is known (perhaps from lookup) but the value of the token itself
+     * is not.
+     *
+     * The value of the `accessToken` parameter takes precedence.
+     */
+    public accessTokenHash?: string
+
+
+    /**
+     * Whether to update the value of the access token in the data store.
+     * If this parameter is set to `true` then a new access token value
+     * is generated by the server and returned in the response.
+     */
+    public accessTokenValueUpdated!: boolean;
+
+
+    /**
+     * The thumbprint of the MTLS certificate bound to this token. If
+     * this field is set, a certificate with the corresponding value MUST
+     * be presented with the access token when it is used by a client.
+     */
+    public certificateThumbprint?: string;
+
+
+    /**
+     * The thumbprint of the public key used for DPoP presentation of
+     * this token. If this field is set, a DPoP proof signed with the
+     * corresponding private key MUST be presented with the access token
+     * when it is used by a client. Additionally, the token's `token_type`
+     * will be set to `'DPoP'`.
+     */
+    public dpopKeyThumbprint?: string;
+
+
+    /**
+     * The authorization details. This represents the value of the
+     * `authorization_details` request parameter which is defined in
+     * _"OAuth 2.0 Rich Authorization Requests"_.
+     */
+    @Type(() => AuthzDetails)
+    public authorizationDetails?: AuthzDetails;
+
+
+    /**
+     * The flag which indicates whether the access token is for an external
+     * attachment.
+     *
+     * For more details, see [OpenID Connect for Identity Assurance 1.0,
+     * External Attachments](https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html#name-external-attachments).
+     */
+    public forExternalAttachment!: boolean;
+
+
+    /**
+     * The token identifier.
+     */
+    public tokenId?: string;
+}

--- a/src/dto/token_update_response.ts
+++ b/src/dto/token_update_response.ts
@@ -1,0 +1,129 @@
+// Copyright (C) 2022 Authlete, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+import ct from 'https://cdn.pika.dev/class-transformer@^0.2.3';
+import 'https://cdn.pika.dev/reflect-metadata@^0.1.13';
+import { ApiResponse } from './api_response.ts';
+import { AuthzDetails } from './authz_details.ts';
+import { Property } from './property.ts';
+const { Type, Transform } = ct;
+
+
+/**
+ * Response from Authlete `/auth/token/update` API.
+ */
+export class TokenUpdateResponse extends ApiResponse
+{
+    /**
+     * The next action that the service implementation should take.
+     */
+    @Transform((value: any) => TokenUpdateResponse.Action[value])
+    public action!: TokenUpdateResponse.Action;
+
+
+    /**
+     * The access token which has been specified by the request.
+     */
+    public accessToken?: string;
+
+
+    /**
+     * The token type associated with the access token.
+     */
+    public tokenType?: string;
+
+
+    /**
+     * The expiration date in milliseconds since the Unix epoch (1970-01-01).
+     */
+    public accessTokenExpiresAt!: number;
+
+
+    /**
+     * The scopes associated with the access token.
+     */
+    public scopes?: string[];
+
+
+    /**
+     * The properties associated with the access token.
+     */
+    @Type(() => Property)
+    public properties?: Property[];
+
+
+    /**
+     * The authorization details. This represents the value of the
+     * `"authorization_details"` request parameter which is defined in
+     * <i>"OAuth 2.0 Rich Authorization Requests"</i>.
+     */
+    @Type(() => AuthzDetails)
+    public authorizationDetails?: AuthzDetails;
+
+
+    /**
+     * The flag which indicates whether the access token is for an external
+     * attachment.
+     *
+     * For more details, see [OpenID Connect for Identity Assurance 1.0,
+     * External Attachments](https://openid.net/specs/openid-connect-4-identity-assurance-1_0.html#name-external-attachments).
+     */
+    public forExternalAttachment!: boolean;
+
+
+    /**
+     * The unique token identifier.
+     */
+    public tokenId?: string;
+}
+
+
+export namespace TokenUpdateResponse
+{
+    /**
+     * The next action that the service implementation should take.
+     */
+    export enum Action
+    {
+        /**
+         * An error occurred on Authlete side.
+         */
+        INTERNAL_SERVER_ERROR,
+
+        /**
+         * The request from the caller was wrong. For example, this
+         * happens when the `accessToken` request parameter was missing.
+         */
+        BAD_REQUEST,
+
+        /**
+         * The request from the caller was not allowed. For example,
+         * this happens when the access token identified by the `accessToken`
+         * request parameter does not belong to the service identified
+         * by the API key used for the API call.
+         */
+        FORBIDDEN,
+
+        /**
+         * The specified access token does not exist.
+         */
+        NOT_FOUND,
+
+        /**
+         * The access token was updated successfully.
+         */
+        OK
+    }
+}


### PR DESCRIPTION
Add support for the following APIs.
- `/auth/token/create` API
- `/auth/token/delete` API
- `/auth/token/get/list` API
- `/auth/token/revoke` API
- `/auth/token/update` API